### PR TITLE
[Fix] dnd-kit listeners와 z-index 업데이트 이벤트 충돌 해결

### DIFF
--- a/src/app/(with-sidebar)/issue/_components/idea-card/idea-card.tsx
+++ b/src/app/(with-sidebar)/issue/_components/idea-card/idea-card.tsx
@@ -117,11 +117,16 @@ export default function IdeaCard(props: IdeaCardProps) {
         }
       : {};
 
-  const handleCardClick = (e: React.MouseEvent) => {
+  const handlePointerDown = (e: React.PointerEvent) => {
+    // z-index 업데이트는 드래그 시작 전에 처리
     if (props.id && !inCategory) {
       bringToFront(props.id);
     }
-    props.onClick?.();
+
+    // listeners의 onPointerDown도 호출 (드래그를 위해)
+    if (!inCategory && listeners?.onPointerDown) {
+      listeners.onPointerDown(e);
+    }
   };
 
   const handleDeleteClick = (e: React.MouseEvent) => {
@@ -135,9 +140,12 @@ export default function IdeaCard(props: IdeaCardProps) {
       status={status}
       isDragging={isDragging}
       inCategory={inCategory}
-      onClick={handleCardClick}
+      onClick={props.onClick}
+      onPointerDown={handlePointerDown}
       {...attributes}
-      {...listeners}
+      {...(inCategory ? {} : Object.fromEntries(
+        Object.entries(listeners || {}).filter(([key]) => key !== 'onPointerDown')
+      ))}
       style={cardStyle}
     >
       {status === 'selected' && (


### PR DESCRIPTION


## 관련 이슈

#62 

---

## 완료 작업

- listeners의 onPointerDown이 커스텀 핸들러를 덮어쓰는 문제 해결
- handlePointerDown 내부에서 listeners.onPointerDown 수동 호출
- listeners 스프레드 시 onPointerDown 제외 처리

