### PR TITLE
[Feat] 아이디어 생성/삭제/이동 SSE 브로드캐스팅 추가

### DIFF
--- a/src/app/(with-sidebar)/issue/[id]/page.tsx
+++ b/src/app/(with-sidebar)/issue/[id]/page.tsx
@@ -64,12 +64,6 @@ const IssuePage = () => {
     }
   }, [status, issueId, router]);
 
-
-  // 1. 이슈 데이터 초기화
-  const { isAIStructuring, isCreateIdeaActive, isVoteButtonVisible, isVoteDisabled } =
-    useIssueData(issueId);
-
-
   // SSE 연결
   useIssueEvents({ issueId, enabled: !!userId });
 


### PR DESCRIPTION
## 관련 이슈

#이슈번호

---

## 완료 작업

- 아이디어 카드 생성/삭제/이동 시에 SSE 브로드캐스팅 로직을 추가했습니다.

---

## 기타

- 이동 시 다른 브라우저에서 갑자기 이동하는 것처럼 보여 추후 클라이언트 처리가 필요할 것 같습니다
