### PR TITLE
[refactor] : CI시 docker image build를 하지 않도록 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+  push:
+    branches: ['dev']
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   build-check:


### PR DESCRIPTION

## 완료 작업
CI에는 프로젝트 빌드 테스트만 하고, docker image build는 테스트하지 않도록 변경했습니다.
도커 이미지 빌드는 CD에서만 수행합니다.

