### PR TITLE
[Feat] 댓글 CRUD 기능 구현

### DIFF
--- a/src/app/api/ideas/[id]/comment/[commentId]/route.ts
+++ b/src/app/api/ideas/[id]/comment/[commentId]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { commentRepository } from '@/lib/repositories/comment.repository';
+
+/**
+ * [PATCH] 기존 댓글 내용 수정 API
+ * 경로: /api/ideas/[id]/comment/[commentId]
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; commentId: string }> },
+): Promise<NextResponse> {
+  const { commentId } = await params;
+  const { content } = await req.json();
+
+  // 필수 데이터 유효성 검사
+  if (!content) {
+    return NextResponse.json({ message: '수정할 댓글 내용을 입력해주세요.' }, { status: 400 });
+  }
+
+  try {
+    // 리포지토리를 통해 댓글 내용 업데이트 수행
+    const comment = await commentRepository.update(commentId, content);
+    return NextResponse.json(comment);
+  } catch (error: any) {
+    console.error('댓글 수정 중 오류 발생:', error);
+
+    // Prisma 에러 코드 P2025: 레코드를 찾을 수 없는 경우
+    if (error.code === 'P2025') {
+      return NextResponse.json({ message: '해당 댓글을 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      { message: '댓글을 수정하는 중에 서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * [DELETE] 댓글 논리 삭제(Soft Delete) API
+ * 경로: /api/ideas/[id]/comment/[commentId]
+ */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; commentId: string }> },
+): Promise<NextResponse> {
+  const { commentId } = await params;
+
+  try {
+    // 리포지토리를 통해 deletedAt 컬럼을 업데이트(논리 삭제)
+    await commentRepository.softDelete(commentId);
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    console.error('댓글 삭제 중 오류 발생:', error);
+
+    // Prisma 에러 코드 P2025: 레코드를 찾을 수 없는 경우
+    if (error.code === 'P2025') {
+      return NextResponse.json({ message: '해당 댓글을 찾을 수 없습니다.' }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      { message: '댓글을 삭제하는 중에 서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/ideas/[id]/comment/route.ts
+++ b/src/app/api/ideas/[id]/comment/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { commentRepository } from '@/lib/repositories/comment.repository';
+
+/**
+ * [GET] 특정 아이디어의 댓글 목록 조회 API
+ * 경로: /api/ideas/[id]/comment
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: ideaId } = await params;
+
+  try {
+    // 리포지토리를 통해 해당 아이디어의 댓글 목록을 가져옴
+    const comments = await commentRepository.findByIdeaId(ideaId);
+    return NextResponse.json({ comments });
+  } catch (error) {
+    console.error('댓글 조회 중 오류 발생:', error);
+    return NextResponse.json(
+      { message: '댓글을 불러오는 중에 서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * [POST] 새로운 댓글 생성 API
+ * 경로: /api/ideas/[id]/comment
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id: ideaId } = await params;
+  const { userId, content } = await req.json();
+
+  // 필수 데이터 유효성 검사
+  if (!userId || !content) {
+    return NextResponse.json(
+      { message: '사용자 ID와 댓글 내용은 필수 입력 사항입니다.' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // 리포지토리를 사용하여 DB에 댓글 생성
+    const comment = await commentRepository.create({
+      ideaId,
+      userId,
+      content,
+    });
+    // 성공 시 201 Created 응답 반환
+    return NextResponse.json(comment, { status: 201 });
+  } catch (error) {
+    console.error('댓글 생성 중 오류 발생:', error);
+    return NextResponse.json(
+      { message: '댓글을 작성하는 중에 서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/api/comment.ts
+++ b/src/lib/api/comment.ts
@@ -1,0 +1,81 @@
+export type Comment = {
+  id: string;
+  content: string;
+  createdAt: Date | string;
+};
+
+/**
+ * 특정 아이디어의 모든 댓글 목록을 조회합니다.
+ * @param ideaId - 아이디어 식별자
+ * @returns 댓글 배열을 포함한 Promise
+ */
+export async function fetchComments(ideaId: string): Promise<Comment[]> {
+  const response = await fetch(`/api/ideas/${ideaId}/comment`);
+
+  if (!response.ok) {
+    throw new Error('댓글을 불러오는 데 실패했습니다.');
+  }
+
+  const data = await response.json();
+  return data.comments;
+}
+
+/**
+ * 새로운 댓글을 생성합니다.
+ * @param ideaId - 아이디어 식별자
+ * @param payload - 유저 ID와 댓글 내용을 포함한 객체
+ */
+export async function createComment(ideaId: string, payload: { userId: string; content: string }) {
+  const response = await fetch(`/api/ideas/${ideaId}/comment`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error('댓글을 작성하는 데 실패했습니다.');
+  }
+
+  return response.json();
+}
+
+/**
+ * 기존 댓글의 내용을 수정합니다.
+ * @param ideaId - 아이디어 식별자
+ * @param commentId - 수정할 댓글 식별자
+ * @param payload - 수정할 댓글 내용
+ */
+export async function updateComment(
+  ideaId: string,
+  commentId: string,
+  payload: { content: string },
+) {
+  const response = await fetch(`/api/ideas/${ideaId}/comment/${commentId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error('댓글을 수정하는 데 실패했습니다.');
+  }
+
+  return response.json();
+}
+
+/**
+ * 댓글을 삭제합니다.
+ * @param ideaId - 아이디어 식별자
+ * @param commentId - 삭제할 댓글 식별자
+ */
+export async function deleteComment(ideaId: string, commentId: string) {
+  const response = await fetch(`/api/ideas/${ideaId}/comment/${commentId}`, {
+    method: 'DELETE',
+  });
+
+  if (!response.ok) {
+    throw new Error('댓글을 삭제하는 데 실패했습니다.');
+  }
+
+  return response.json();
+}

--- a/src/lib/repositories/comment.repository.ts
+++ b/src/lib/repositories/comment.repository.ts
@@ -1,0 +1,77 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * 댓글 데이터 관리를 위한 리포지토리 객체
+ */
+export const commentRepository = {
+  /**
+   * 특정 아이디어에 속한 삭제되지 않은 모든 댓글을 조회합니다.
+   * @param ideaId - 조회할 아이디어의 ID
+   * @returns 생성일 기준 오름차순으로 정렬된 댓글 목록
+   */
+  async findByIdeaId(ideaId: string) {
+    return prisma.comment.findMany({
+      where: {
+        ideaId,
+        deletedAt: null, // 삭제되지 않은 댓글만 조회 (Soft Delete 필터링)
+      },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+      },
+    });
+  },
+
+  /**
+   * 새로운 댓글을 생성합니다.
+   * @param data - 아이디어 ID, 유저 ID, 댓글 내용을 포함하는 데이터 객체
+   * @returns 생성된 댓글의 주요 정보 (ID, 내용, 생성일)
+   */
+  async create(data: { ideaId: string; userId: string; content: string }) {
+    return prisma.comment.create({
+      data: {
+        ideaId: data.ideaId,
+        userId: data.userId,
+        content: data.content,
+      },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+      },
+    });
+  },
+
+  /**
+   * 기존 댓글의 내용을 수정합니다.
+   * @param commentId - 수정할 댓글의 식별자
+   * @param content - 수정될 새로운 댓글 내용
+   * @returns 수정이 완료된 댓글 정보
+   */
+  async update(commentId: string, content: string) {
+    return prisma.comment.update({
+      where: { id: commentId },
+      data: { content },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+      },
+    });
+  },
+
+  /**
+   * 댓글을 논리 삭제(Soft Delete) 처리합니다.
+   * 실제 데이터를 삭제하지 않고 삭제 일시를 기록합니다.
+   * @param commentId - 삭제 처리할 댓글의 식별자
+   * @returns 업데이트된 댓글 객체
+   */
+  async softDelete(commentId: string) {
+    return prisma.comment.update({
+      where: { id: commentId },
+      data: { deletedAt: new Date() },
+    });
+  },
+};

--- a/test/repositories/comment.repository.test.ts
+++ b/test/repositories/comment.repository.test.ts
@@ -1,0 +1,126 @@
+import { prisma } from '@/lib/prisma';
+import { commentRepository } from '@/lib/repositories/comment.repository';
+
+// Prisma 클라이언트 모킹
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    comment: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+const mockedPrismaComment = prisma.comment as jest.Mocked<typeof prisma.comment>;
+
+/**
+ * 댓글 리포지토리 테스트
+ */
+describe('Comment Repository 테스트', () => {
+  // 테스트용 공통 데이터 정의
+  const ideaId = 'idea-123';
+  const commentId = 'comment-1';
+  const userId = 'user-123';
+  const content = '테스트 댓글 내용';
+  const mockDate = new Date();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findByIdeaId (댓글 목록 조회)', () => {
+    it('삭제되지 않은 댓글을 생성일 기준 오름차순으로 반환해야 한다', async () => {
+      // Given
+      const mockComments = [
+        { id: 'comment-1', content: '첫 번째 댓글', createdAt: mockDate },
+        { id: 'comment-2', content: '두 번째 댓글', createdAt: mockDate },
+      ];
+      mockedPrismaComment.findMany.mockResolvedValue(mockComments as any);
+
+      // When
+      const result = await commentRepository.findByIdeaId(ideaId);
+
+      // Then
+      expect(mockedPrismaComment.findMany).toHaveBeenCalledWith({
+        where: {
+          ideaId,
+          deletedAt: null, // Soft Delete 필터링 확인
+        },
+        orderBy: { createdAt: 'asc' },
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+        },
+      });
+      expect(result).toEqual(mockComments);
+    });
+  });
+
+  describe('create (댓글 생성)', () => {
+    it('새로운 댓글을 생성하고 지정된 필드를 반환해야 한다', async () => {
+      // Given
+      const input = { ideaId, userId, content };
+      const mockCreatedComment = { id: commentId, content, createdAt: mockDate };
+      mockedPrismaComment.create.mockResolvedValue(mockCreatedComment as any);
+
+      // When
+      const result = await commentRepository.create(input);
+
+      // Then
+      expect(mockedPrismaComment.create).toHaveBeenCalledWith({
+        data: {
+          ideaId: input.ideaId,
+          userId: input.userId,
+          content: input.content,
+        },
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+        },
+      });
+      expect(result).toEqual(mockCreatedComment);
+    });
+  });
+
+  describe('update (댓글 수정)', () => {
+    it('댓글 내용을 수정하고 업데이트된 필드를 반환해야 한다', async () => {
+      // Given
+      const updatedContent = '수정된 댓글 내용';
+      const mockUpdatedComment = { id: commentId, content: updatedContent, createdAt: mockDate };
+      mockedPrismaComment.update.mockResolvedValue(mockUpdatedComment as any);
+
+      // When
+      const result = await commentRepository.update(commentId, updatedContent);
+
+      // Then
+      expect(mockedPrismaComment.update).toHaveBeenCalledWith({
+        where: { id: commentId },
+        data: { content: updatedContent },
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+        },
+      });
+      expect(result).toEqual(mockUpdatedComment);
+    });
+  });
+
+  describe('softDelete (댓글 논리 삭제)', () => {
+    it('댓글의 deletedAt 필드에 현재 시간을 기록해야 한다', async () => {
+      // Given
+      mockedPrismaComment.update.mockResolvedValue({ id: commentId } as any);
+
+      // When
+      await commentRepository.softDelete(commentId);
+
+      // Then
+      const updateCall = mockedPrismaComment.update.mock.calls[0][0];
+      expect(updateCall.where).toEqual({ id: commentId });
+      expect(updateCall.data.deletedAt).toBeInstanceOf(Date); // 날짜 객체가 전달되었는지 확인
+    });
+  });
+});


### PR DESCRIPTION
## 관련 이슈

close #177

---

## 완료 작업

- 댓글 CRUD 백엔드 로직 구현을 위한 레포지토리 추가 (`src/lib/repositories/comment.repository.ts`)
- 댓글 API 라우트 추가
  - 단건 댓글 CRUD: `src/app/api/ideas/[id]/comment/[commentId]/route.ts`
  - 댓글 목록/생성: `src/app/api/ideas/[id]/comment/route.ts`
- 댓글 API 호출 유틸 추가 (`src/lib/api/comment.ts`)
- 댓글 레포지토리 테스트 추가 (`test/repositories/comment.repository.test.ts`)

---

## 기타

- 테스트 실행 여부: 미실행 (필요 시 `test/repositories/comment.repository.test.ts` 실행 권장)
- 리뷰 집중 포인트: 라우팅 설계 및 레포지토리 메서드 시그니처/에러 처리 흐름

---

## 테스트 결과

<img width="434" height="364" alt="image" src="https://github.com/user-attachments/assets/ea88ac9e-831e-4153-9620-ffb344d8da4b" />