### PR TITLE
[Feat] 이슈 생성 기능 추가

### DIFF
--- a/src/app/(with-sidebar)/issue/[id]/page.tsx
+++ b/src/app/(with-sidebar)/issue/[id]/page.tsx
@@ -27,10 +27,10 @@ import {
 } from '../hooks';
 
 const IssuePage = () => {
-  const params = useParams<{ id: string }>();
+  const params = useParams<{ id: string; issueId?: string }>();
   const pathname = usePathname();
   const issueIdFromPath = pathname?.split('/issue/')[1]?.split('/')[0] ?? '';
-  const issueId = Array.isArray(params.id) ? params.id[0] : (params.id ?? issueIdFromPath);
+  const issueId = params.issueId ?? (Array.isArray(params.id) ? params.id[0] : (params.id ?? issueIdFromPath));
   const router = useRouter();
   const { openModal, isOpen } = useModalStore();
   const hasOpenedModal = useRef(false);

--- a/src/app/(with-sidebar)/topic/[id]/issue/[issueId]/page.tsx
+++ b/src/app/(with-sidebar)/topic/[id]/issue/[issueId]/page.tsx
@@ -1,0 +1,3 @@
+import IssuePage from '@/app/(with-sidebar)/issue/[id]/page';
+
+export default IssuePage;

--- a/src/app/(with-sidebar)/topic/_components/create-issue-button/create-issue-button.tsx
+++ b/src/app/(with-sidebar)/topic/_components/create-issue-button/create-issue-button.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useModalStore } from '@/components/modal/use-modal-store';
+import HeaderButton from '../../../issue/_components/header/header-button';
+import CreateIssueModal from '../create-issue-modal/create-issue-modal';
+
+export default function CreateIssueButton() {
+  const { openModal } = useModalStore();
+
+  const handleClick = () => {
+    openModal({
+      title: '새 이슈 만들기',
+      content: <CreateIssueModal />,
+      hasCloseButton: true,
+    });
+  };
+
+  return (
+    <HeaderButton
+      imageSrc="/white-add.svg"
+      alt="새 이슈"
+      text="새 이슈"
+      variant="solid"
+      color="green"
+      onClick={handleClick}
+    />
+  );
+}

--- a/src/app/(with-sidebar)/topic/_components/create-issue-modal/create-issue-modal.tsx
+++ b/src/app/(with-sidebar)/topic/_components/create-issue-modal/create-issue-modal.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+import * as S from '@/app/(with-sidebar)/issue/_components/issue-join-modal/issue-join-modal.styles';
+import { useModalStore } from '@/components/modal/use-modal-store';
+import { useMutation } from '@tanstack/react-query';
+import { createIssueInTopic } from '@/lib/api/issue';
+
+export default function CreateIssueModal() {
+  const router = useRouter();
+  const params = useParams();
+  const topicId = params.id as string;
+  const [issueTitle, setIssueTitle] = useState('');
+  const { closeModal } = useModalStore();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (title: string) => createIssueInTopic(topicId, title),
+    onSuccess: (data) => {
+      toast.success('이슈가 생성되었습니다!');
+      closeModal();
+      router.push(`/topic/${topicId}/issue/${data.issueId}`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '이슈 생성에 실패했습니다.');
+    },
+  });
+
+  const handleCreate = async () => {
+    if (!issueTitle.trim()) {
+      toast.error('이슈 제목을 입력해주세요.');
+      return;
+    }
+
+    if (!topicId) {
+      toast.error('토픽 ID를 찾을 수 없습니다.');
+      return;
+    }
+
+    mutate(issueTitle);
+  };
+
+  return (
+    <S.Container>
+      <S.InfoContainer>
+        <S.InputWrapper>
+          <S.InputTitle>이슈 제목</S.InputTitle>
+          <S.Input
+            value={issueTitle}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIssueTitle(e.target.value)}
+            placeholder="제목을 입력하세요"
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              if (e.key === 'Enter' && !isPending) {
+                handleCreate();
+              }
+            }}
+            autoFocus
+            disabled={isPending}
+          />
+        </S.InputWrapper>
+      </S.InfoContainer>
+
+      <S.Footer>
+        <S.SubmitButton
+          type="button"
+          onClick={handleCreate}
+          disabled={isPending}
+        >
+          {isPending ? '생성 중...' : '만들기'}
+        </S.SubmitButton>
+      </S.Footer>
+    </S.Container>
+  );
+}

--- a/src/app/(with-sidebar)/topic/_components/header/topic-header.styles.ts
+++ b/src/app/(with-sidebar)/topic/_components/header/topic-header.styles.ts
@@ -9,6 +9,7 @@ export const HeaderContainer = styled.div`
   background-color: white;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   border-bottom: 1px solid ${theme.colors.gray[100]};
 `;
 

--- a/src/app/(with-sidebar)/topic/_components/header/topic-header.tsx
+++ b/src/app/(with-sidebar)/topic/_components/header/topic-header.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import * as S from './topic-header.styles';
+import CreateIssueButton from '../create-issue-button/create-issue-button';
 
 export default function TopicHeader() {
   return (
@@ -15,6 +16,7 @@ export default function TopicHeader() {
         />
         토픽 제목
       </S.LeftSection>
+      <CreateIssueButton />
     </S.HeaderContainer>
   );
 }

--- a/src/app/api/topics/[topicId]/issues/route.ts
+++ b/src/app/api/topics/[topicId]/issues/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { createIssue } from '@/lib/repositories/issue.repository';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function GET(
@@ -27,5 +28,28 @@ export async function GET(
   } catch (error) {
     console.error('이슈 조회 실패:', error);
     return createErrorResponse('ISSUES_FETCH_FAILED', 500);
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ topicId: string }> },
+) {
+  const { topicId } = await params;
+  const { title } = await req.json();
+
+  if (!title) {
+    return createErrorResponse('TITLE_REQUIRED', 400);
+  }
+
+  try {
+    const issue = await prisma.$transaction(async (tx) => {
+      return await createIssue(tx, title, topicId);
+    });
+
+    return createSuccessResponse({ issueId: issue.id }, 201);
+  } catch (error) {
+    console.error('토픽 이슈 생성 실패:', error);
+    return createErrorResponse('ISSUE_CREATE_FAILED', 500);
   }
 }

--- a/src/lib/api/issue.ts
+++ b/src/lib/api/issue.ts
@@ -139,3 +139,14 @@ export function selectIdea(issueId: string, selectedIdeaId: string) {
     body: JSON.stringify({ selectedIdeaId }),
   });
 }
+
+export function createIssueInTopic(topicId: string, title: string) {
+  return getAPIResponseData<{
+    issueId: string;
+  }>({
+    url: `/api/topics/${topicId}/issues`,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
+}

--- a/src/lib/repositories/issue.repository.ts
+++ b/src/lib/repositories/issue.repository.ts
@@ -4,9 +4,16 @@ import { PrismaTransaction } from '@/types/prisma';
 
 type PrismaClientOrTx = PrismaTransaction | typeof prisma;
 
-export async function createIssue(tx: PrismaTransaction, title: string) {
+export async function createIssue(
+  tx: PrismaTransaction,
+  title: string,
+  topicId?: string,
+) {
   return tx.issue.create({
-    data: { title },
+    data: {
+      title,
+      ...(topicId && { topicId }),
+    },
   });
 }
 


### PR DESCRIPTION
## 관련 이슈

https://github.com/user-attachments/assets/f88cd677-5af0-4715-a3a8-23737159a8da


#217 
---

## 완료 작업

### 이슈 생성 기능 추가
- 토픽 헤더에 이슈 추가 버튼을 추가했습니다.
- 이슈 추가 버튼을 누르면 이슈 추가 모달이 뜨도록 구현했습니다.
- 이슈 추가 후 생성된 이슈로 리디렉션 되도록 구현했습니다.

### 토픽 아래 이슈 페이지 생성
- 토픽 아래에도 이슈페이지가 존재하도록 추가했습니다.
  - 경로는 /topic/[id]/issue/[IssueId]입니다.
- 이슈 페이지에서 topicId와 IssueId를 구분하도록 변경했습니다.

### issue.repository에서 이슈 생성 로직에 topicId 옵셔널로 추가
- 이슈가 topicId를 가질 수 있도록 추가했습니다.

---

## 기타

- TanstackQuery 로직들이 각 경로의 hook이 아니라, 공통 hook으로 이동되어야할 것 같습니다.
- project/[projectId], topic/[topicId] 처럼 명확한 id이름을 써야 경로 파싱할 때 용이할 것 같습니다.