### PR TITLE
[Test] 인증 관련 유틸 함수 및 미들웨어에 대한 단위 테스트 추가

### DIFF
--- a/test/auth/api-auth.test.ts
+++ b/test/auth/api-auth.test.ts
@@ -1,0 +1,87 @@
+// API 인증 유틸(getAuthenticatedUserId/getUserIdFromHeader) 단위 테스트
+// 테스트에서 사용할 요청 생성 헬퍼
+import { createMockRequest } from '@test/utils/api-test-helpers';
+
+// next-auth의 getServerSession을 모킹하여 세션 유무를 제어
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+// authOptions 의존성을 제거하기 위한 모킹
+jest.mock('@/lib/auth', () => ({
+  authOptions: {},
+}));
+
+describe('api-auth', () => {
+  beforeEach(() => {
+    // 테스트 간 모킹 상태 초기화
+    jest.clearAllMocks();
+  });
+
+  it('getUserIdFromHeader는 x-user-id를 반환한다', async () => {
+    // 테스트 대상 함수 로드
+    const { getUserIdFromHeader } = await import('@/lib/utils/api-auth');
+
+    // x-user-id 헤더가 있는 요청 생성
+    const req = createMockRequest(undefined, {
+      headers: { 'x-user-id': 'user-1' },
+      method: 'GET',
+    });
+
+    // 헤더 값이 그대로 반환되는지 확인
+    expect(getUserIdFromHeader(req)).toBe('user-1');
+  });
+
+  it('getUserIdFromHeader는 없으면 null을 반환한다', async () => {
+    // 테스트 대상 함수 로드
+    const { getUserIdFromHeader } = await import('@/lib/utils/api-auth');
+
+    // 헤더 없는 요청 생성
+    const req = createMockRequest(undefined, { method: 'GET' });
+
+    // 헤더가 없으므로 null 반환 확인
+    expect(getUserIdFromHeader(req)).toBeNull();
+  });
+
+  it('getAuthenticatedUserId는 세션이 없으면 UNAUTHORIZED를 반환한다', async () => {
+    // 테스트 대상 함수 로드
+    const { getAuthenticatedUserId } = await import('@/lib/utils/api-auth');
+    // 모킹된 getServerSession 획득
+    const { getServerSession } = await import('next-auth');
+
+    // 세션 없음으로 설정
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    // 실행
+    const result = await getAuthenticatedUserId();
+
+    // userId가 null인지 확인
+    expect(result.userId).toBeNull();
+    // 에러 객체 존재 확인
+    expect(result.error).toBeDefined();
+    // 401 상태 확인
+    expect(result.error!.status).toBe(401);
+
+    // 에러 코드 확인
+    const body = await result.error!.json();
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('getAuthenticatedUserId는 세션이 있으면 userId를 반환한다', async () => {
+    // 테스트 대상 함수 로드
+    const { getAuthenticatedUserId } = await import('@/lib/utils/api-auth');
+    // 모킹된 getServerSession 획득
+    const { getServerSession } = await import('next-auth');
+
+    // 세션이 있는 경우로 설정
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: 'user-1' } });
+
+    // 실행
+    const result = await getAuthenticatedUserId();
+
+    // userId가 반환되는지 확인
+    expect(result.userId).toBe('user-1');
+    // 에러가 없는지 확인
+    expect(result.error).toBeNull();
+  });
+});

--- a/test/auth/auth-options.test.ts
+++ b/test/auth/auth-options.test.ts
@@ -1,0 +1,115 @@
+/// <reference path="../../src/types/next-auth.d.ts" />
+// authOptions 설정(어댑터/콜백) 단위 테스트
+// NextAuth 어댑터 타입
+import type { Adapter, AdapterUser } from 'next-auth/adapters';
+// prisma 모킹 대상
+import { prisma } from '@/lib/prisma';
+
+// prisma.user.create를 모킹
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+// PrismaAdapter 자체를 단순 객체로 모킹
+jest.mock('@auth/prisma-adapter', () => ({
+  PrismaAdapter: () => ({}),
+}));
+
+describe('authOptions', () => {
+  // prisma 모킹 인스턴스 캐스팅
+  const mockedPrisma = prisma as jest.Mocked<typeof prisma>;
+
+  beforeEach(() => {
+    // 테스트 간 모킹 상태 초기화
+    jest.clearAllMocks();
+  });
+
+  it('createUser는 displayName을 name으로 저장한다', async () => {
+    // authOptions 로드
+    const { authOptions } = await import('@/lib/auth');
+    // 어댑터에서 createUser 추출
+    const adapter = authOptions.adapter as Adapter;
+
+    // createUser에 전달될 입력 데이터
+    const data: Omit<AdapterUser, 'id'> = {
+      name: '홍길동',
+      email: 'hong@example.com',
+      image: 'https://example.com/img.png',
+      emailVerified: null,
+    };
+
+    // prisma.user.create의 반환값 설정
+    const mockedCreate = prisma.user.create as jest.MockedFunction<typeof prisma.user.create>;
+    mockedCreate.mockResolvedValue({ id: 'user-1' } as any);
+
+    const createUser = (
+      authOptions.adapter as {
+        createUser: (user: Omit<AdapterUser, 'id'>) => Promise<any>;
+      }
+    ).createUser!;
+
+    // createUser 실행
+    await createUser(data);
+
+    // displayName이 name과 동일하게 저장되는지 검증
+    expect(mockedPrisma.user.create).toHaveBeenCalledWith({
+      data: {
+        ...data,
+        displayName: '홍길동',
+      },
+    });
+  });
+
+  it('session 콜백은 token.sub를 session.user.id로 주입한다', async () => {
+    // authOptions 로드
+    const { authOptions } = await import('@/lib/auth');
+
+    // 기존 세션/토큰 준비
+    const session = { user: { id: 'old-id', name: 'User' } } as any;
+    const token = { sub: 'new-id' } as any;
+
+    // session 콜백 실행
+    const result = await authOptions.callbacks!.session!({ session, token } as any);
+
+    // user.id가 token.sub로 변경되었는지 확인
+    expect((result as any).user.id).toBe('new-id');
+  });
+
+  it('jwt 콜백은 update 트리거에서 name을 갱신한다', async () => {
+    // authOptions 로드
+    const { authOptions } = await import('@/lib/auth');
+
+    // 토큰/세션 준비
+    const token = { name: 'old' } as any;
+    const session = { name: 'new' } as any;
+
+    // jwt 콜백 실행 (trigger=update)
+    const result = await authOptions.callbacks!.jwt!({
+      token,
+      trigger: 'update',
+      session,
+    } as any);
+
+    // token.name이 갱신되었는지 확인
+    expect(result.name).toBe('new');
+  });
+
+  it('jwt 콜백은 user가 있으면 token.id를 설정한다', async () => {
+    // authOptions 로드
+    const { authOptions } = await import('@/lib/auth');
+
+    // 토큰/유저 준비
+    const token = {} as any;
+    const user = { id: 'user-1' } as any;
+
+    // jwt 콜백 실행
+    const result = await authOptions.callbacks!.jwt!({ token, user } as any);
+
+    // token.id가 설정되었는지 확인
+    expect(result.id).toBe('user-1');
+  });
+});

--- a/test/auth/cookie.test.ts
+++ b/test/auth/cookie.test.ts
@@ -1,0 +1,81 @@
+// 이슈 쿠키 유틸(set/get) 단위 테스트
+// next/headers의 cookies 함수 모킹 대상
+import { cookies } from 'next/headers';
+
+// cookies() 호출을 모킹
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+describe('cookie utils', () => {
+  // 모킹된 cookies 함수 캐스팅
+  const mockedCookies = cookies as jest.MockedFunction<typeof cookies>;
+
+  beforeEach(() => {
+    // 모킹 상태 초기화
+    jest.clearAllMocks();
+  });
+
+  it('setUserIdCookie는 issue-user-id 쿠키를 설정한다', async () => {
+    // 테스트 대상 함수 로드
+    const { setUserIdCookie } = await import('@/lib/utils/cookie');
+    // 쿠키 스토어 모킹
+    const cookieStore = { set: jest.fn() } as any;
+
+    // cookies()가 스토어를 반환하도록 설정
+    mockedCookies.mockResolvedValue(cookieStore);
+
+    // 쿠키 설정 실행
+    await setUserIdCookie('issue-1', 'user-1');
+
+    // set 호출 인자 검증
+    expect(cookieStore.set).toHaveBeenCalledWith(
+      'issue-user-id-issue-1',
+      'user-1',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24,
+        secure: process.env.NODE_ENV === 'production',
+      }),
+    );
+  });
+
+  it('getUserIdFromRequest는 요청 쿠키에서 값을 반환한다', async () => {
+    // 테스트 대상 함수 로드
+    const { getUserIdFromRequest } = await import('@/lib/utils/cookie');
+
+    // 요청 객체에 쿠키 getter 모킹
+    const req = {
+      cookies: {
+        get: jest.fn().mockReturnValue({ value: 'user-1' }),
+      },
+    } as any;
+
+    // 반환값 검증
+    expect(getUserIdFromRequest(req, 'issue-1')).toBe('user-1');
+    // 특정 키로 쿠키 조회했는지 확인
+    expect(req.cookies.get).toHaveBeenCalledWith('issue-user-id-issue-1');
+  });
+
+  it('getUserIdFromServer는 서버 쿠키에서 값을 반환한다', async () => {
+    // 테스트 대상 함수 로드
+    const { getUserIdFromServer } = await import('@/lib/utils/cookie');
+    // 쿠키 스토어 모킹
+    const cookieStore = {
+      get: jest.fn().mockReturnValue({ value: 'user-2' }),
+    } as any;
+
+    // cookies()가 스토어를 반환하도록 설정
+    mockedCookies.mockResolvedValue(cookieStore);
+
+    // 서버에서 쿠키 조회 실행
+    const result = await getUserIdFromServer('issue-1');
+
+    // 조회 키 확인
+    expect(cookieStore.get).toHaveBeenCalledWith('issue-user-id-issue-1');
+    // 반환값 확인
+    expect(result).toBe('user-2');
+  });
+});

--- a/test/auth/issue-user-storage.test.ts
+++ b/test/auth/issue-user-storage.test.ts
@@ -1,0 +1,76 @@
+// 익명 이슈 사용자 ID 로컬스토리지 유틸 단위 테스트
+// 테스트 대상 함수
+import { getUserIdForIssue, setUserIdForIssue } from '@/lib/storage/issue-user-storage';
+
+describe('issue-user-storage', () => {
+  // 로컬스토리지 목 객체 생성 함수
+  const createLocalStorageMock = () => {
+    // in-memory 저장소
+    let store: Record<string, string> = {};
+
+    return {
+      // 키로 조회
+      getItem: jest.fn((key: string) => store[key] ?? null),
+      // 키로 저장
+      setItem: jest.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      // 전체 초기화
+      clear: jest.fn(() => {
+        store = {};
+      }),
+    };
+  };
+
+  beforeEach(() => {
+    // 각 테스트마다 새로운 localStorage 주입
+    const localStorageMock = createLocalStorageMock();
+    (globalThis as any).window = { localStorage: localStorageMock };
+    (globalThis as any).localStorage = localStorageMock;
+  });
+
+  afterEach(() => {
+    // 전역 오염 방지
+    delete (globalThis as any).window;
+    delete (globalThis as any).localStorage;
+  });
+
+  it('저장된 값이 없으면 undefined를 반환한다', () => {
+    // 저장 전 조회
+    const result = getUserIdForIssue('issue-1');
+    // undefined 반환 확인
+    expect(result).toBeUndefined();
+  });
+
+  it('setUserIdForIssue 이후 getUserIdForIssue로 조회된다', () => {
+    // 사용자 ID 저장
+    setUserIdForIssue('issue-1', 'user-1');
+
+    // 저장 후 조회
+    const result = getUserIdForIssue('issue-1');
+
+    // 저장된 값이 조회되는지 확인
+    expect(result).toBe('user-1');
+  });
+
+  it('손상된 JSON이 있어도 에러 없이 처리된다', () => {
+    // 에러 로그를 감시하기 위한 spy
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // 잘못된 JSON을 반환하도록 조작
+    (globalThis as any).window.localStorage.getItem = jest
+      .fn()
+      .mockReturnValue('not-json');
+
+    // 조회 시도
+    const result = getUserIdForIssue('issue-1');
+
+    // 실패 시 undefined 반환 확인
+    expect(result).toBeUndefined();
+    // 에러 로그가 호출되었는지 확인
+    expect(consoleSpy).toHaveBeenCalled();
+
+    // spy 복구
+    consoleSpy.mockRestore();
+  });
+});

--- a/test/auth/proxy.test.ts
+++ b/test/auth/proxy.test.ts
@@ -1,0 +1,88 @@
+// proxy.ts 미들웨어(NextAuth 토큰 → x-user-id 주입) 단위 테스트
+// NextRequest 타입 사용
+import { NextRequest } from 'next/server';
+// getToken 모킹 대상
+import { getToken } from 'next-auth/jwt';
+// GET 요청 헬퍼
+import { createMockGetRequest } from '@test/utils/api-test-helpers';
+// 테스트 대상 함수
+import { proxy } from '@/proxy';
+
+// getToken을 모킹하여 토큰 존재 여부를 제어
+jest.mock('next-auth/jwt', () => ({
+  getToken: jest.fn(),
+}));
+
+describe('proxy', () => {
+  // getToken 모킹 인스턴스 캐스팅
+  const mockedGetToken = getToken as jest.MockedFunction<typeof getToken>;
+
+  beforeEach(() => {
+    // 모킹 상태 초기화
+    jest.clearAllMocks();
+    // 테스트용 시크릿 설정
+    process.env.NEXTAUTH_SECRET = 'test-secret';
+  });
+
+  it('토큰이 없으면 401을 반환한다', async () => {
+    // 토큰 없음으로 설정
+    mockedGetToken.mockResolvedValue(null);
+
+    // 요청 생성
+    const req = createMockGetRequest();
+    // proxy 실행
+    const response = await proxy(req as NextRequest);
+
+    // 401 응답 확인
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.message).toBe('UNAUTHORIZED');
+  });
+
+  it('token.sub가 있으면 x-user-id를 주입한다', async () => {
+    // sub 포함 토큰 설정
+    mockedGetToken.mockResolvedValue({ sub: 'user-1' } as any);
+
+    // 요청 생성
+    const req = createMockGetRequest();
+    // proxy 실행
+    const response = await proxy(req as NextRequest);
+
+    // 정상 응답 확인
+    expect(response.status).toBe(200);
+    // 미들웨어가 주입한 헤더 확인
+    expect(response.headers.get('x-middleware-request-x-user-id')).toBe('user-1');
+    // override 헤더 목록에 x-user-id 포함 여부 확인
+    expect(response.headers.get('x-middleware-override-headers')).toContain('x-user-id');
+  });
+
+  it('token.sub가 없고 token.id가 있으면 id를 사용한다', async () => {
+    // id만 있는 토큰 설정
+    mockedGetToken.mockResolvedValue({ id: 'user-2' } as any);
+
+    // 요청 생성
+    const req = createMockGetRequest();
+    // proxy 실행
+    const response = await proxy(req as NextRequest);
+
+    // 정상 응답 확인
+    expect(response.status).toBe(200);
+    // id가 헤더에 주입되는지 확인
+    expect(response.headers.get('x-middleware-request-x-user-id')).toBe('user-2');
+  });
+
+  it('token에서 userId를 찾을 수 없으면 401을 반환한다', async () => {
+    // 빈 토큰 설정
+    mockedGetToken.mockResolvedValue({} as any);
+
+    // 요청 생성
+    const req = createMockGetRequest();
+    // proxy 실행
+    const response = await proxy(req as NextRequest);
+
+    // 401 응답 확인
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.message).toBe('UNAUTHORIZED');
+  });
+});


### PR DESCRIPTION
## 관련 이슈

---

## 완료 작업

- Auth 관련 Util, Proxy, 설정 로직을 단위테스트로 커버하도록 test/auth에 테스트를 추가
- authOptions에서 타입 확장 충돌은 reference path로 해결했습니다.
  - next-auth.d.ts에서 next-auth 타입에 대한 확장을 Jest는 런타임에 읽지 못함
  - 따라서 reference path를 이용해 컴파일 시점에 타입 확장 파일을 포함
 
---

## 기타
