### PR TITLE
[Fix] 아이디어 카드와 댓글 리스트 겹치는 문제 해결

### DIFF
--- a/src/app/(with-sidebar)/issue/_components/idea-card/idea-card.styles.ts
+++ b/src/app/(with-sidebar)/issue/_components/idea-card/idea-card.styles.ts
@@ -62,11 +62,12 @@ export const Card = styled.article<{
   isHotIdea?: boolean;
 }>`
   position: relative;
+  z-index: ${({ isCommentOpen, isHotIdea }) => (isCommentOpen ? 1001 : isHotIdea ? 100 : 1)};
   border-radius: ${theme.radius.medium};
   padding: 35px 35px 30px 35px;
   box-shadow: 0 4px 10px rgba(31, 41, 55, 0.06);
-  ${({ isHotIdea, status }) =>
-    isHotIdea
+  ${({ isHotIdea, status, isCommentOpen }) =>
+    isHotIdea && !isCommentOpen
       ? `
     z-index: 100;
     border: 2px solid ${theme.colors.red[500]};
@@ -105,24 +106,24 @@ export const Card = styled.article<{
 
   &:hover {
     ${({ issueStatus, status }) => {
-      if (issueStatus === ISSUE_STATUS.SELECT && status !== 'selected') {
-        return `
+    if (issueStatus === ISSUE_STATUS.SELECT && status !== 'selected') {
+      return `
         border: 2px solid ${theme.colors.yellow[400]} !important;
         background: ${theme.colors.white};
         box-shadow: 0 4px 10px rgba(252, 220, 89, 0.86) !important;
         `;
-      }
-      // 채택된 상태에서 호버 시 노란색 유지
-      if (status === 'selected') {
-        return `
+    }
+    // 채택된 상태에서 호버 시 노란색 유지
+    if (status === 'selected') {
+      return `
         border: 2px solid ${theme.colors.yellow[500]} !important;
         `;
-      }
-    }}
+    }
+  }}
   }
 
-  ${({ isHotIdea, status }) =>
-    isHotIdea && status !== 'selected'
+  ${({ isHotIdea, status, isCommentOpen }) =>
+    isHotIdea && status !== 'selected' && !isCommentOpen
       ? `
     z-index: 100;
     border: 2px solid ${theme.colors.red[500]} !important;
@@ -312,11 +313,11 @@ export const VoteButton = styled.button<{
 
   &:hover {
     ${({ kind, active, cardStatus }) => {
-      if (active || cardStatus === 'selected') return '';
-      if (kind === VOTE_TYPE.AGREE)
-        return `background: ${theme.colors.green[600]}; color: ${theme.colors.white};`;
-      return `background: ${theme.colors.red[600]}; color: ${theme.colors.white};`;
-    }}
+    if (active || cardStatus === 'selected') return '';
+    if (kind === VOTE_TYPE.AGREE)
+      return `background: ${theme.colors.green[600]}; color: ${theme.colors.white};`;
+    return `background: ${theme.colors.red[600]}; color: ${theme.colors.white};`;
+  }}
   }
 
   &:disabled {


### PR DESCRIPTION
## 완료 작업

우선순위 역전 방지: isHotIdea일 때 z-index를 주는 로직에 !isCommentOpen 조건을 추가

```ts
  ${({ isHotIdea, status, isCommentOpen }) =>
    isHotIdea && !isCommentOpen
```

**개선 전**

<img width="582" height="448" alt="image" src="https://github.com/user-attachments/assets/d8d22184-bb02-417d-9969-3d478174f51f" />

**개선 후**

<img width="692" height="457" alt="image" src="https://github.com/user-attachments/assets/eda382d0-b22e-4cc2-a17b-45a959f7f67c" />
