### PR TITLE
[Fix] 진행 상태 애니메이션 수정

### DIFF
--- a/src/app/(with-sidebar)/issue/_components/progress-bar/progress-bar.tsx
+++ b/src/app/(with-sidebar)/issue/_components/progress-bar/progress-bar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { STATUS_LABEL, STEP_FLOW } from '@/constants/issue';
 import { useIssueData, useIssueId } from '../../hooks';
 import * as S from './progress-bar.styles';
@@ -7,13 +8,31 @@ const PROGRESS_BAR_DURATION = 0.3;
 const ProgressBar = () => {
   const issueId = useIssueId();
   const { status } = useIssueData(issueId);
-  const currentIndex = STEP_FLOW.indexOf(status);
+  const [animatedIndex, setAnimatedIndex] = useState(0);
+
+  useEffect(() => {
+    const targetIndex = STEP_FLOW.indexOf(status);
+    if (targetIndex <= animatedIndex) return;
+
+    let i = animatedIndex;
+
+    const interval = setInterval(() => {
+      i += 1;
+      setAnimatedIndex(i);
+
+      if (i >= targetIndex) {
+        clearInterval(interval);
+      }
+    }, PROGRESS_BAR_DURATION * 1000);
+
+    return () => clearInterval(interval);
+  }, [status]);
 
   return (
     <S.Container>
       {STEP_FLOW.map((step, index) => {
-        const isActive = index <= currentIndex;
-        const isLineActive = index < currentIndex;
+        const isActive = index <= animatedIndex;
+        const isLineActive = index < animatedIndex;
         const showLine = index < STEP_FLOW.length - 1;
 
         return (


### PR DESCRIPTION
## 구현 영상

https://github.com/user-attachments/assets/730694a4-d57c-4b78-b88e-e8ff75da6003


---

## 완료 작업

### ProgressBar 단계 순차 애니메이션 개선
- 기존 ProgressBar는 이슈 상태가 변경될 때 모든 단계의 선과 원이 동시에 활성화되었다.
- 이를 개선하기 위해 animatedIndex를 도입하여, 실제 status가 가리키는 단계까지 한 단계씩 순차적으로 진행되도록 로직을 변경했다.

- **흐름**
  - status 변경 시 목표 단계(targetIndex)를 계산
  - setInterval을 사용해 animatedIndex를 일정 시간 간격으로 1씩 증가
  - 각 단계의 활성화 여부를 animatedIndex 기준으로 판단
    - 원(Circle): index <= animatedIndex
    - 선(Line): index < animatedIndex
  - 이를 통해 선 → 다음 원 → 다음 선 → 다음 원 순으로 자연스럽게 채워지는 애니메이션 구현

