### PR TITLE
[Test] routes 인증 관련 테스트 실패 해결(dev에 merge)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,9 @@
 /** @type {import('jest').Config} */
 const config = {
-  // ts-jest로 TS 테스트 파일을 즉시 변환합니다.
-  preset: 'ts-jest',
   // 기본 테스트 환경(Node.js API, DOM 아님)
   testEnvironment: 'node',
   // Jest가 탐색할 폴더 범위를 제한합니다.
-  roots: ['<rootDir>/test'],
+  roots: ['<rootDir>/test', '<rootDir>/src'],
   // 테스트 파일로 인식할 패턴입니다.
   testMatch: ['<rootDir>/test/**/*.test.ts', '<rootDir>/test/**/*.spec.ts'],
   moduleNameMapper: {
@@ -17,14 +15,18 @@ const config = {
     // node_modules는 기본적으로 변환하지 않고, 아래 패키지만 예외로 처리합니다(prisma-adapger, next-auth).
     'node_modules/(?!(@auth/prisma-adapter|next-auth)/)',
   ],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }],
+  },
   // 커버리지 대상 파일(타입 정의, 스토리북 제외)
   // collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
 
   // 일단 tsx는 제외
-  collectCoverageFrom: ['src/**/*.{ts}', '!src/**/*.d.ts'],
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
 
   // 커버리지 리포트 출력 폴더
   coverageDirectory: 'coverage',
+  coverageProvider: 'babel',
   // 테스트 간 목을 자동 초기화합니다.
   clearMocks: true,
   resetMocks: true,

--- a/src/app/api/projects/[projectId]/members/[memberId]/route.ts
+++ b/src/app/api/projects/[projectId]/members/[memberId]/route.ts
@@ -1,12 +1,16 @@
 import { LeaveService } from '@/lib/services/leave.service';
-import { getUserIdFromHeader } from '@/lib/utils/api-auth';
+import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function DELETE(
   req: Request,
   { params }: { params: Promise<{ projectId: string; memberId: string }> },
 ) {
-  const userId = getUserIdFromHeader(req)!;
+  const { userId, error } = await getAuthenticatedUserId(req);
+
+  if (!userId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
 
   try {
     const { projectId } = await params;

--- a/src/app/api/projects/[projectId]/members/route.ts
+++ b/src/app/api/projects/[projectId]/members/route.ts
@@ -1,21 +1,21 @@
-import { findUserById } from '@/lib/repositories/user.repository';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { InvitationService } from '@/lib/services/invitation.service';
-import { getUserIdFromHeader } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function POST(req: Request, { params }: { params: Promise<{ projectId: string }> }) {
   try {
-    const userId = getUserIdFromHeader(req)!;
+    const session = await getServerSession(authOptions);
+    const userId = session?.user?.id ?? null;
+    const userEmail = session?.user?.email ?? null;
 
-    const user = await findUserById(userId);
-
-    if (!user?.email) {
+    if (!userId || !userEmail) {
       return createErrorResponse('UNAUTHORIZED_USER', 401);
     }
 
     const { token } = await req.json();
 
-    const result = await InvitationService.acceptInvitation(token, user.email, userId);
+    const result = await InvitationService.acceptInvitation(token, userEmail, userId);
 
     return createSuccessResponse(result, 201);
   } catch (error: any) {

--- a/src/app/api/projects/[projectId]/route.ts
+++ b/src/app/api/projects/[projectId]/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest } from 'next/server';
 import * as projectRepository from '@/lib/repositories/project.repository';
+import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ projectId: string }> },
 ) {
+  const { userId, error } = await getAuthenticatedUserId(req);
+
+  if (!userId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
+
   const { projectId } = await params;
 
   try {
@@ -26,6 +33,12 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ projectId: string }> },
 ) {
+  const { userId, error } = await getAuthenticatedUserId(req);
+
+  if (!userId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
+
   const { projectId } = await params;
   const { title, description } = await req.json();
 

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,15 +1,19 @@
 import { NextRequest } from 'next/server';
 import * as projectRepository from '@/lib/repositories/project.repository';
-import { getUserIdFromHeader } from '@/lib/utils/api-auth';
+import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function GET(req: NextRequest) {
-  const ownerId = getUserIdFromHeader(req);
+  const { userId: ownerId, error } = await getAuthenticatedUserId(req);
+
+  if (!ownerId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
 
   try {
     // 내 소유의 프로젝트와 게트스로 참여중인 프로젝트를 모두 불려옴
-    const myOwnProjects = await projectRepository.getProjectsByOwnerId(ownerId!);
-    const guestProjects = await projectRepository.getProjectsByMemberId(ownerId!);
+    const myOwnProjects = await projectRepository.getProjectsByOwnerId(ownerId);
+    const guestProjects = await projectRepository.getProjectsByMemberId(ownerId);
     const projects = [...myOwnProjects, ...guestProjects];
     return createSuccessResponse(projects, 200);
   } catch (error) {
@@ -19,7 +23,11 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const ownerId = getUserIdFromHeader(req);
+  const { userId: ownerId, error } = await getAuthenticatedUserId(req);
+
+  if (!ownerId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
 
   const { title, description } = await req.json();
 
@@ -28,7 +36,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const result = await projectRepository.createProject(title, ownerId!, description);
+    const result = await projectRepository.createProject(title, ownerId, description);
     return createSuccessResponse(result, 201);
   } catch (error) {
     console.error('프로젝트 생성 실패:', error);
@@ -37,7 +45,11 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  const ownerId = getUserIdFromHeader(req);
+  const { userId: ownerId, error } = await getAuthenticatedUserId(req);
+
+  if (!ownerId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
 
   const { id } = await req.json();
 
@@ -46,7 +58,7 @@ export async function DELETE(req: NextRequest) {
   }
 
   try {
-    const result = await projectRepository.deleteProject(id, ownerId!);
+    const result = await projectRepository.deleteProject(id, ownerId);
     return createSuccessResponse(result, 200);
   } catch (error) {
     console.error('프로젝트 삭제 실패:', error);

--- a/src/app/api/topics/[topicId]/issues/route.ts
+++ b/src/app/api/topics/[topicId]/issues/route.ts
@@ -3,7 +3,7 @@ import { IssueRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { issueMemberRepository } from '@/lib/repositories/issue-member.repository';
 import { createIssue } from '@/lib/repositories/issue.repository';
-import { getUserIdFromHeader } from '@/lib/utils/api-auth';
+import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ topicId: string }> }) {
@@ -34,7 +34,11 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ top
 export async function POST(req: NextRequest, { params }: { params: Promise<{ topicId: string }> }) {
   const { topicId } = await params;
   const { title } = await req.json();
-  const userId = getUserIdFromHeader(req)!;
+  const { userId, error } = await getAuthenticatedUserId(req);
+
+  if (!userId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
 
   if (!title) {
     return createErrorResponse('TITLE_REQUIRED', 400);

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest } from 'next/server';
 import * as topicRepository from '@/lib/repositories/topic.repository';
+import { getAuthenticatedUserId } from '@/lib/utils/api-auth';
 import { createErrorResponse, createSuccessResponse } from '@/lib/utils/api-helpers';
 
 export async function POST(req: NextRequest) {
+  const { userId, error } = await getAuthenticatedUserId(req);
+
+  if (!userId) {
+    return error ?? createErrorResponse('UNAUTHORIZED', 401);
+  }
+
   const { title, projectId } = await req.json();
 
   if (!title) {

--- a/src/lib/utils/api-auth.ts
+++ b/src/lib/utils/api-auth.ts
@@ -3,10 +3,19 @@ import { NextRequest } from 'next/server';
 import { authOptions } from '@/lib/auth';
 import { createErrorResponse } from '@/lib/utils/api-helpers';
 
-export async function getAuthenticatedUserId() {
+export async function getAuthenticatedUserId(request?: Request | NextRequest) {
+  const headerUserId = request ? getUserIdFromHeader(request) : null;
+
+  if (headerUserId) {
+    return {
+      userId: headerUserId,
+      error: null,
+    };
+  }
+
   const session = await getServerSession(authOptions);
 
-  if (!session || !session.user) {
+  if (!session || !session.user || !session.user.id) {
     return {
       userId: null,
       error: createErrorResponse('UNAUTHORIZED', 401),

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}


### PR DESCRIPTION
## 완료 작업
- projects와 topics의 route에서 auth 인증 테스트 실패 문제를 해결했습니다.
- proxy.ts에서 인증 및 에러 반환을 담당하므로 route.ts들에서 뺐었는데 테스트에는 유지되어있던게 문제였습니다.
- 테스트에서 인증실패를 빼기보다는, 코드에 인증실패시 로직을 추가하는게 좋겠다고 생각해서 추가했습니다.
  - 깔끔한건 proxy.ts에서만 검증 및 에러반환을 하는건데, 테스터블한 코드 및 안정성 기준으로는 route에도 있는게 좋겠다고 판단했습니다.

- 백엔드 로직에 대한 테스트코드가 어느정도 완성되었습니다.(90% 정도?)
- 미비한 부분 약간 있지만 치명적이지 않다고 생각합니다.
- 테스트 작성하면서 코드도 많이 뜯어봤는데 이제 백엔드 쪽은 어느정도 신뢰할만 하다고 생각합니다
- 즉, 이후 버그들은 프론트엔드 쪽이 많을 것이라고 생각합니다....

<img width="1510" height="820" alt="스크린샷 2026-01-28 오전 2 33 43" src="https://github.com/user-attachments/assets/49b72ac2-362e-4391-b556-393a3959b50a" />