### PR TITLE
[Feat] 사이드바 검색바에 드롭박스 추가

### DIFF
--- a/src/app/(with-sidebar)/issue/_components/layout/issue-sidebar.tsx
+++ b/src/app/(with-sidebar)/issue/_components/layout/issue-sidebar.tsx
@@ -1,5 +1,8 @@
+import styled from '@emotion/styled';
+import { theme } from '@/styles/theme';
 import MemberSidebarItem from '@/components/sidebar/member-sidebar-item';
 import Sidebar from '@/components/sidebar/sidebar';
+import SidebarFilter from '@/components/sidebar/sidebar-filter';
 import SidebarItem from '@/components/sidebar/sidebar-item';
 import * as S from '@/components/sidebar/sidebar.styles';
 import { ISSUE_STATUS } from '@/constants/issue';
@@ -32,6 +35,8 @@ export default function IssueSidebar() {
     showIssueList,
     isSummaryPage,
     goToIssueMap,
+    searchTarget,
+    setSearchTarget,
   } = useIssueSidebar();
 
   return (
@@ -40,6 +45,12 @@ export default function IssueSidebar() {
         value: searchValue,
         onChange: handleSearchChange,
       }}
+      suffix={
+        <SidebarFilter
+          value={searchTarget}
+          onChange={setSearchTarget}
+        />
+      }
     >
       {isMounted && showIssueList && (
         <>

--- a/src/app/(with-sidebar)/issue/_components/layout/use-issue-sidebar.ts
+++ b/src/app/(with-sidebar)/issue/_components/layout/use-issue-sidebar.ts
@@ -42,6 +42,7 @@ export const useIssueSidebar = () => {
   // 검색 관련 상태
   const [searchValue, setSearchValue] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
+  const [searchTarget, setSearchTarget] = useState<'issue' | 'member'>('issue');
 
   // 멤버 정렬: 소유자 > 온라인 > 이름순
   const sortedMembers = useMemo(() => {
@@ -80,29 +81,38 @@ export const useIssueSidebar = () => {
 
   // 멤버 검색 필터링
   const filteredMembers = useMemo(() => {
+    // 멤버 검색 모드가 아니면 전체 반환
+    if (searchTarget !== 'member') return sortedMembers;
+
     const { trimmed, normalized, searchChoseong } = searchParams;
     if (!trimmed) return sortedMembers;
 
     return sortedMembers.filter((member) =>
       matchSearch(member.nickname || '익명', normalized, searchChoseong),
     );
-  }, [searchParams, sortedMembers]);
+  }, [searchParams, sortedMembers, searchTarget]);
 
   // 이슈 검색 필터링
   const filteredIssues = useMemo(() => {
+    // 이슈 검색 모드가 아니면 전체 반환
+    if (searchTarget !== 'issue') return topicIssues;
+
     const { trimmed, normalized, searchChoseong } = searchParams;
     if (!trimmed) return topicIssues;
 
     return topicIssues.filter((issue) => matchSearch(issue.title || '', normalized, searchChoseong));
-  }, [searchParams, topicIssues]);
+  }, [searchParams, topicIssues, searchTarget]);
 
   // 정적 이슈 리스트 필터링
   const filteredStaticIssues = useMemo(() => {
+    // 이슈 검색 모드가 아니면 전체 반환
+    if (searchTarget !== 'issue') return ISSUE_LIST;
+
     const { trimmed, normalized, searchChoseong } = searchParams;
     if (!trimmed) return ISSUE_LIST;
 
     return ISSUE_LIST.filter((issue) => matchSearch(issue.title || '', normalized, searchChoseong));
-  }, [searchParams]);
+  }, [searchParams, searchTarget]);
 
   // 검색어 입력 핸들러
   const handleSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
@@ -161,5 +171,7 @@ export const useIssueSidebar = () => {
 
     // 액션
     goToIssueMap,
+    searchTarget,
+    setSearchTarget,
   };
 };

--- a/src/components/sidebar/sidebar-filter.styles.ts
+++ b/src/components/sidebar/sidebar-filter.styles.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import styled from '@emotion/styled';
+import { theme } from '@/styles/theme';
+
+export const Container = styled.div`
+  position: relative;
+`;
+
+export const Trigger = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  font-size: ${theme.font.size.small};
+  font-weight: ${theme.font.weight.bold};
+  color: ${theme.colors.gray[600]};
+  cursor: pointer;
+  padding: 4px;
+  white-space: nowrap;
+
+  &:hover {
+    color: ${theme.colors.gray[800]};
+  }
+
+  &::after {
+    content: '';
+    display: block;
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 4px solid currentColor;
+    margin-top: 2px;
+  }
+`;
+
+export const Menu = styled.ul`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 8px;
+  background-color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.gray[200]};
+  border-radius: 8px;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  list-style: none;
+  padding: 4px;
+  z-index: 10;
+  min-width: 80px;
+`;
+
+export const MenuItem = styled.li<{ isActive?: boolean }>`
+  width: 100%;
+
+  button {
+    width: 100%;
+    text-align: left;
+    padding: 8px 12px;
+    background-color: ${({ isActive, theme }) => (isActive ? theme.colors.gray[200] : 'transparent')};
+    border: none;
+    border-radius: 4px;
+    font-size: ${theme.font.size.small};
+    color: ${({ isActive, theme }) => (isActive ? theme.colors.gray[900] : theme.colors.gray[600])};
+    cursor: pointer;
+    white-space: nowrap;
+
+    &:hover {
+      background-color: ${({ isActive, theme }) => (isActive ? theme.colors.gray[200] : theme.colors.gray[100])};
+      color: ${theme.colors.gray[900]};
+    }
+  }
+`;

--- a/src/components/sidebar/sidebar-filter.tsx
+++ b/src/components/sidebar/sidebar-filter.tsx
@@ -1,0 +1,47 @@
+import { useState, useRef, useEffect } from 'react';
+import * as S from './sidebar-filter.styles';
+
+interface SidebarFilterProps {
+  value: 'issue' | 'member';
+  onChange: (value: 'issue' | 'member') => void;
+}
+
+export default function SidebarFilter({ value, onChange }: SidebarFilterProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const filterRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (filterRef.current && !filterRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleSelect = (newValue: 'issue' | 'member') => {
+    onChange(newValue);
+    setIsOpen(false);
+  };
+
+  return (
+    <S.Container ref={filterRef}>
+      <S.Trigger onClick={() => setIsOpen(!isOpen)}>
+        {value === 'issue' ? '이슈' : '멤버'}
+      </S.Trigger>
+      {isOpen && (
+        <S.Menu>
+          <S.MenuItem isActive={value === 'issue'}>
+            <button onClick={() => handleSelect('issue')}>이슈</button>
+          </S.MenuItem>
+          <S.MenuItem isActive={value === 'member'}>
+            <button onClick={() => handleSelect('member')}>멤버</button>
+          </S.MenuItem>
+        </S.Menu>
+      )}
+    </S.Container>
+  );
+}

--- a/src/components/sidebar/sidebar.styles.ts
+++ b/src/components/sidebar/sidebar.styles.ts
@@ -22,18 +22,22 @@ export const Sidebar = styled.aside`
 
 export const InputWrapper = styled.div`
   display: flex;
-  padding: 0 16px;
-  position: relative;
+  align-items: center;
+  margin: 0 16px;
+  padding: 0;
+  gap: 8px;
+  border-bottom: 1px solid ${theme.colors.gray[200]};
+`;
 
-  &:has(input:focus) img {
-    visibility: hidden;
-  }
+export const SearchBox = styled.div`
+  position: relative;
+  flex: 1;
 `;
 
 export const InputIcon = styled(Image)`
   position: absolute;
   top: 50%;
-  left: 16px;
+  left: 0;
   transform: translateY(-50%);
 `;
 
@@ -51,9 +55,8 @@ export const SrOnly = styled.label`
 `;
 export const SidebarInput = styled.input`
   width: 100%;
-  padding: 8px;
+  padding: 8px 8px 8px 24px;
   border: none;
-  border-bottom: 1px solid ${theme.colors.gray[200]};
 `;
 
 export const SidebarTitle = styled.div`

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -4,26 +4,30 @@ import * as S from './sidebar.styles';
 interface SidebarProps {
   children: ReactNode;
   inputProps?: InputHTMLAttributes<HTMLInputElement>;
+  suffix?: ReactNode;
 }
 
-export default function Sidebar({ children, inputProps }: SidebarProps) {
+export default function Sidebar({ children, inputProps, suffix }: SidebarProps) {
   const inputId = inputProps?.id ?? 'sidebar';
 
   return (
     <S.Sidebar>
       <S.InputWrapper>
-        <S.InputIcon
-          src="/magnifier.svg"
-          alt="돋보기 이미지"
-          width={16}
-          height={16}
-        />
-        <S.SrOnly htmlFor={inputId}>Search</S.SrOnly>
-        <S.SidebarInput
-          id={inputId}
-          type="text"
-          {...inputProps}
-        />
+        <S.SearchBox>
+          <S.InputIcon
+            src="/magnifier.svg"
+            alt="돋보기 이미지"
+            width={16}
+            height={16}
+          />
+          <S.SrOnly htmlFor={inputId}>Search</S.SrOnly>
+          <S.SidebarInput
+            id={inputId}
+            type="text"
+            {...inputProps}
+          />
+        </S.SearchBox>
+        {suffix}
       </S.InputWrapper>
       {children}
     </S.Sidebar>


### PR DESCRIPTION
## 관련 이슈

close #308 

---

## 완료 작업

- **사이드바 검색 필터 추가**: 검색창 좌측에 `이슈` / `멤버`를 선택할 수 있는 드롭다운 필터를 구현했습니다.
- **검색 모드 전환 기능**: 필터 선택에 따라 사이드바에 노출되는 리스트(이슈 목록 vs 멤버 목록)가 변경되도록 처리했습니다.
- **UI/UX 개선**: 
  - 드롭다운 메뉴 스타일 적용
  - 외부 영역 클릭 시 드롭다운이 닫히도록 `useRef`를 활용한 이벤트 처리

https://github.com/user-attachments/assets/312a37fa-e294-4254-845a-49e81bb0e88c