### PR TITLE
[fix] 비방장 모달 닫힘 브로드캐스트 차단

### DIFF
--- a/src/app/(with-sidebar)/issue/hooks/use-issue-events.ts
+++ b/src/app/(with-sidebar)/issue/hooks/use-issue-events.ts
@@ -268,6 +268,7 @@ export function useIssueEvents({
         submitButtonText: '이슈 종료',
         onClose: async () => {
           // 모달 닫힘 시 다른 클라이언트에게 브로드캐스팅
+          if (!isOwnerRef.current) return;
           try {
             await deleteCloseModal(issueId);
           } catch (error) {


### PR DESCRIPTION
## 관련 이슈

#313

---

## 완료 작업

### 배경

이슈 종료모달에서 종료버튼 클릭 시 방장이 아닌 다른 클라이언트에 에러발생.


<img width="559" height="473" alt="스크린샷 2026-01-29 오후 2 15 20" src="https://github.com/user-attachments/assets/fb1e2ed8-5cdb-485f-923b-4f2f1f722fe2" />



### 문제원인

 모달이 SSE로 닫힐 때도 onClose가 실행돼서, 방장이 아닌 클라이언트가 deleteCloseModal 호출 → 권한 에러 발생.

### 해결
  - SSE로 종료 모달이 닫힐 때 비방장 클라이언트가 deleteCloseModal을 호출하지 않도록 가드 추가
  - 방장만 종료 모달 닫힘 이벤트를 브로드캐스트하도록 수정

---

## 기타

<!-- 코드 리뷰 시 참고할 사항을 작성해주세요 -->
<!-- 특히 주의깊게 봐야 하는 파일이나 코드가 있다면 명시해주세요 -->
<!-- 구현 중 고민했던 부분이나 리뷰어에게 질문하고 싶은 내용을 적어주세요 -->
