### PR TITLE
[Refactor] 이슈 접근 시 유저 검증, SSE 연결 시점 변경

### DIFF
--- a/src/app/(with-sidebar)/issue/[id]/page.tsx
+++ b/src/app/(with-sidebar)/issue/[id]/page.tsx
@@ -167,7 +167,7 @@ const IssuePage = () => {
 
   // SSE 연결
   // 빠른 이슈는 localStorage userId, 토픽 이슈는 로그인 userId 기준으로 연결
-  const shouldConnectSSE = !!currentUserId;
+  const shouldConnectSSE = !isPageLoading && !!currentUserId && !isAuthError && !isMemberError;
   useIssueEvents({
     issueId,
     userId: currentUserId,


### PR DESCRIPTION
## 관련 이슈

#이슈번호

---

## 완료 작업

<!-- 이 PR에서 완료된 주요 내용을 간단히 설명해주세요 -->
- 로그인하지 않은 경우/ 프로젝트 멤버가 아닌 경우 -> 권한이 없는 상황인데 메인페이지로 이동하기 전에 아이디어 목록이 보이는 문제
- 권한이 없는 경우에는 return null을 하여 아이디어 카드를 볼 수 없도록 변경


- 프로젝트 멤버가 아닌 경우에도 sse 이벤트 연결되는 문제
- 현재 sse 연결 기준이 currentUser 기준이라서 로그인한 경우에는 우선 sse 연결이 됩니다
- 에러가 없는 경우에만 이벤트에 연결되도록 수정했습니다

<img width="747" height="719" alt="스크린샷 2026-01-29 오후 2 52 22" src="https://github.com/user-attachments/assets/7c7f3388-b828-4312-be54-4a223954fc2e" />


---

## 기타

<!-- 코드 리뷰 시 참고할 사항을 작성해주세요 -->
<!-- 특히 주의깊게 봐야 하는 파일이나 코드가 있다면 명시해주세요 -->
<!-- 구현 중 고민했던 부분이나 리뷰어에게 질문하고 싶은 내용을 적어주세요 -->
