### PR TITLE
[Feat] 기타 카테고리를 기본 속성으로 수정

### DIFF
--- a/src/app/(with-sidebar)/issue/[id]/page.tsx
+++ b/src/app/(with-sidebar)/issue/[id]/page.tsx
@@ -296,7 +296,6 @@ const IssuePage = () => {
                   {...category}
                   issueId={issueId}
                   hasActiveComment={hasActiveComment}
-                  isMuted={category.title === '기타'}
                   onPositionChange={handleCategoryPositionChange}
                   checkCollision={checkCategoryOverlap}
                   onRemove={() => handleDeleteCategory(category.id)}
@@ -352,31 +351,31 @@ const IssuePage = () => {
           <DragOverlay dropAnimation={null}>
             {activeId
               ? (() => {
-                  const activeIdea = ideas.find((idea) => idea.id === activeId);
-                  if (!activeIdea) return null;
+                const activeIdea = ideas.find((idea) => idea.id === activeId);
+                if (!activeIdea) return null;
 
-                  return (
-                    <div
-                      style={{
-                        transform: `scale(${scale})`,
-                        transformOrigin: '0 0', // 왼쪽 위 기준으로 scale
-                      }}
-                    >
-                      <IdeaCard
-                        {...activeIdea}
-                        issueId={issueId}
-                        content={overlayEditValue ?? activeIdea.content}
-                        position={null}
-                        isSelected={activeIdea.id === selectedIdeaId}
-                        author={activeIdea.author}
-                        userId={activeIdea.userId}
-                        status={getIdeaStatus(activeIdea.id)}
-                        isVoteButtonVisible={isVoteButtonVisible}
-                        isVoteDisabled={isVoteDisabled}
-                      />
-                    </div>
-                  );
-                })()
+                return (
+                  <div
+                    style={{
+                      transform: `scale(${scale})`,
+                      transformOrigin: '0 0', // 왼쪽 위 기준으로 scale
+                    }}
+                  >
+                    <IdeaCard
+                      {...activeIdea}
+                      issueId={issueId}
+                      content={overlayEditValue ?? activeIdea.content}
+                      position={null}
+                      isSelected={activeIdea.id === selectedIdeaId}
+                      author={activeIdea.author}
+                      userId={activeIdea.userId}
+                      status={getIdeaStatus(activeIdea.id)}
+                      isVoteButtonVisible={isVoteButtonVisible}
+                      isVoteDisabled={isVoteDisabled}
+                    />
+                  </div>
+                );
+              })()
               : null}
           </DragOverlay>
         )}


### PR DESCRIPTION
## 관련 이슈

#이슈번호

---

## 완료 작업

카테고리 이름이 `기타`인 경우 적용되던 `isMuted` 스타일을 제거하였습니다.

<img width="894" height="584" alt="image" src="https://github.com/user-attachments/assets/8358f9d0-92ec-4bc9-8b45-b06052760c32" />

---

## 기타

근데, 아이디어 분류를 잘 못해주네요..