### PR TITLE
[Fix] AI 카테고리화 진행 시 빈 카테고리가 생기는 현상 해결

### DIFF
--- a/src/lib/repositories/category.repository.ts
+++ b/src/lib/repositories/category.repository.ts
@@ -38,7 +38,7 @@ export const categoryRepository = {
 
   async createManyForIssue(
     issueId: string,
-    categories: Array<{ title: string }>,
+    categories: Array<{ title: string; ideaIds: string[] }>,
     tx: Prisma.TransactionClient = prisma,
   ) {
     return Promise.all(
@@ -49,6 +49,9 @@ export const categoryRepository = {
             title: category.title,
             positionX: 100 + index * 600,
             positionY: 100,
+            ideas: {
+              connect: category.ideaIds.map((id) => ({ id })),
+            },
           },
         }),
       ),
@@ -100,8 +103,8 @@ export const categoryRepository = {
     });
   },
 
-  async softDelete(categoryId: string) {
-    return prisma.category.update({
+  async softDelete(categoryId: string, tx: Prisma.TransactionClient = prisma) {
+    return tx.category.update({
       where: { id: categoryId },
       data: { deletedAt: new Date() },
     });

--- a/test/repositories/category.repository.test.ts
+++ b/test/repositories/category.repository.test.ts
@@ -71,7 +71,10 @@ describe('Category Repository 테스트', () => {
 
   it('이슈에 속한 카테고리를 일괄 생성하고 기본 좌표를 부여한다', async () => {
     const issueId = 'issue-1';
-    const categories = [{ title: 'A' }, { title: 'B' }];
+    const categories = [
+      { title: 'A', ideaIds: ['idea-1'] },
+      { title: 'B', ideaIds: ['idea-2'] },
+    ];
     const mockTx = {
       category: {
         create: jest
@@ -89,6 +92,9 @@ describe('Category Repository 테스트', () => {
         title: 'A',
         positionX: 100,
         positionY: 100,
+        ideas: {
+          connect: [{ id: 'idea-1' }],
+        },
       },
     });
     expect(mockTx.category.create).toHaveBeenCalledWith({
@@ -97,6 +103,9 @@ describe('Category Repository 테스트', () => {
         title: 'B',
         positionX: 700,
         positionY: 100,
+        ideas: {
+          connect: [{ id: 'idea-2' }],
+        },
       },
     });
     expect(result).toHaveLength(2);
@@ -105,7 +114,7 @@ describe('Category Repository 테스트', () => {
   it('카테고리 일괄 생성은 트랜잭션 미전달 시 기본 prisma로 처리된다', async () => {
     mockedCategory.create.mockResolvedValue({ id: 'category-1' } as any);
 
-    await categoryRepository.createManyForIssue('issue-1', [{ title: 'A' }]);
+    await categoryRepository.createManyForIssue('issue-1', [{ title: 'A', ideaIds: [] }]);
 
     expect(mockedCategory.create).toHaveBeenCalledWith({
       data: {
@@ -113,6 +122,9 @@ describe('Category Repository 테스트', () => {
         title: 'A',
         positionX: 100,
         positionY: 100,
+        ideas: {
+          connect: [],
+        },
       },
     });
   });


### PR DESCRIPTION
## 관련 이슈

close #331

---

## 완료 작업

### 1. 카테고리화 로직 최적화 및 리팩토링 `categorize.service.ts`

- **DB 연산 최적화**: 기존에 "카테고리 생성 -> 아이디어 업데이트 -> 빈 카테고리 삭제"로 이어지던 3단계 DB 작업을 **단일 `create` 트랜잭션**으로 통합했습니다.
  - `prisma.category.create`의 `connect` 기능을 사용하여 카테고리 생성 시점에 아이디어를 바로 연결합니다.

```ts
  async createManyForIssue(
    issueId: string,
    categories: Array<{ title: string; ideaIds: string[] }>,
    tx: Prisma.TransactionClient = prisma,
  ) {
  /* ... */
            ideas: {
              connect: category.ideaIds.map((id) => ({ id })),
            },
   /* ... */
  },
```

  - 사전에 빈 카테고리를 필터링하여 불필요한 `delete` 연산을 제거했습니다.
  - 미분류 아이디어를 사전에 계산하여 '기타' 카테고리도 `create` 단계에 포함시켰습니다.

- **코드 리팩토링**: 복잡했던 전처리 로직(중복 제거, 미분류 아이디어 처리, 빈 카테고리 필터링)을 `_processCategoryPayloads` 헬퍼 함수로 추출하여 메인 로직의 가독성을 높였습니다.