### PR TITLE
[Refactor] 도커 컴포즈를 올릴 때, 자동으로 shadow db를 만들도록 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - --collation-server=utf8mb4_unicode_ci
     volumes:
       - ./data/mysql:/var/lib/mysql
+      - ./docker/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   redis:
     image: redis:7.0

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -1,0 +1,4 @@
+-- Shadow Database for Prisma Migrate
+CREATE DATABASE IF NOT EXISTS `murphy_shadow_db`;
+GRANT ALL PRIVILEGES ON `murphy_shadow_db`.* TO 'app_user'@'%';
+FLUSH PRIVILEGES;

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   },
   datasource: {
     url: process.env.DATABASE_URL!,
+    shadowDatabaseUrl: process.env.SHADOW_DATABASE_URL,
   },
 });


### PR DESCRIPTION
## 완료 작업
- docker-compose up 으로 데이터베이스에 도커를 올릴 때 자동으로 쉐도우 DB를 만들도록 변경했습니다.
- 프로젝트 클론 후, 의존성 설치, 도커 컨테이너 띄우기, 마이그레이션 3단계만으로 바로 실행 가능하도록 변경했습니다.