### PR TITLE
[Refactor] 프론트엔드 성능 측정

### DIFF
--- a/src/app/(with-sidebar)/issue/[id]/summary/_components/word-cloud/word-cloud.tsx
+++ b/src/app/(with-sidebar)/issue/[id]/summary/_components/word-cloud/word-cloud.tsx
@@ -82,7 +82,7 @@ export default function WordCloudSection() {
           const normalized = (weight - min) / range;
           return minFontSize + normalized * sizeRange;
         },
-        fontFamily: 'Pretendard, sans-serif',
+        fontFamily: 'var(--font-pretendard), sans-serif',
         fontWeight: '600',
         color: (_word: string, weight: number) => {
           const normalized = (weight - min) / range;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import 'pretendard/dist/web/static/pretendard.css';
 import { Toaster } from 'react-hot-toast';
 import Modal from '@/components/modal/modal';
 import Tooltip from '@/components/tooltip/tooltip';
@@ -7,6 +6,7 @@ import { AuthProvider } from '@/providers/auth-provider';
 import { Providers } from '@/providers/query-provider';
 import ThemeProvider from '@/providers/theme-provider';
 import EmotionRegistry from '@/styles/EmotionRegistry';
+import { pretendard } from '@/styles/fonts';
 import GlobalStyle from '@/styles/globalStyles';
 
 export const metadata: Metadata = {
@@ -23,7 +23,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>
+      <body className={`${pretendard.variable} ${pretendard.className}`}>
         <EmotionRegistry>
           <AuthProvider>
             <Providers>

--- a/src/styles/fonts.ts
+++ b/src/styles/fonts.ts
@@ -1,0 +1,28 @@
+import localFont from 'next/font/local';
+
+export const pretendard = localFont({
+  src: [
+    {
+      path: '../../node_modules/pretendard/dist/web/static/woff2/Pretendard-Regular.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: '../../node_modules/pretendard/dist/web/static/woff2/Pretendard-Medium.woff2',
+      weight: '500',
+      style: 'normal',
+    },
+    {
+      path: '../../node_modules/pretendard/dist/web/static/woff2/Pretendard-SemiBold.woff2',
+      weight: '600',
+      style: 'normal',
+    },
+    {
+      path: '../../node_modules/pretendard/dist/web/static/woff2/Pretendard-Bold.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+  ],
+  variable: '--font-pretendard',
+  display: 'swap',
+});

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -8,7 +8,7 @@ export const global = css`
 
   body {
     font-family:
-      'Pretendard',
+      var(--font-pretendard),
       -apple-system,
       BlinkMacSystemFont,
       'Apple SD Gothic Neo',


### PR DESCRIPTION
## 관련 이슈

#이슈번호

---

## 완료 작업
- Pretendard 폰트를 **next/font/local 방식으로 전환**
    - 전역 CSS import 제거
    - 필요한 weight만 로딩하도록 구성
    - font-display: swap 적용
- 폰트 적용 방식 변경에 따라 전역 스타일 및 일부 컴포넌트의 font-family 수정
- Lighthouse 기준 **프론트엔드 성능 측정 및 분석 진행**
    - 메인 페이지 / 랜딩 페이지
    - 이슈 페이지(/issue/[id]) 성능 비교 확인

## **성능 측정 결과 요약**

- **배포 환경 기준**
    - 메인 페이지 및 랜딩 페이지의 Performance 점수는 전반적으로 양호
    - FCP, CLS, TBT 지표 모두 안정적인 수준
- **로컬 환경 기준**
    - 메인/랜딩 페이지는 문제 없음
    - 다만, **이슈 페이지에서 Performance 점수가 상대적으로 낮게 측정됨**

## **이슈 페이지 Performance 저하 원인 분석**

Lighthouse 및 LCP Breakdown 분석 결과,

- 서버 응답(TTFB)이나 리소스 로딩 문제는 아님
- **LCP 요소가 이미지가 아닌 div(텍스트/레이아웃)로 잡힘**
- 해당 영역이 **Client Component 기반**으로 구성되어 있어, 초기 렌더 시 **hydration 완료를 기다리는 시간**이 발생
    - 이로 인해 Element render delay가 상대적으로 크게 측정됨

즉, 현재 성능 저하는 네트워크나 번들 크기 문제가 아니라 **Client Component 비중이 높은 구조적 특성에 따른 렌더링 지연**으로 판단됨.

## **결론 및 이후 개선 방향**

- 현재 성능 수치는 실사용에 문제 있는 수준은 아님
- 다만, 이슈 페이지의 LCP 개선을 위해 다음과 같은 개선을 해야할듯
    - **LCP 영역을 Server Component로 분리**
    - 혹은 초기 렌더에 불필요한 Client Component 의존성 축소
---

## 기타

[조금 더 자세한 분석](https://ethereal-canidae-ba8.notion.site/2fbfec439d36806c8e6ceed7e722edd1?source=copy_link)
