### PR TITLE
[Feat] 댓글 등록 후 입력창 포커스 유지

### DIFF
--- a/src/app/(with-sidebar)/issue/_components/comment/hooks/use-comment-window.ts
+++ b/src/app/(with-sidebar)/issue/_components/comment/hooks/use-comment-window.ts
@@ -88,6 +88,11 @@ export function useCommentWindow({
       try {
         await createMutation.mutateAsync({ userId, content: trimmed });
         setInputValue('');
+        if (target) {
+          requestAnimationFrame(() => {
+            target.focus();
+          });
+        }
       } catch {
         // tanstack error state에 의해 에러 처리
       }


### PR DESCRIPTION
## 관련 이슈

#366 

---

## 완료 작업

https://github.com/user-attachments/assets/02d6cfdb-b133-4121-ab29-d845f2348eb0



댓글 생성 성공 시 입력값 초기화 후 포커스를 다시 입력창에 맞춰 연속 입력이 끊기지 않도록 했습니다.



`focus`는 브라우저가 입장에서 화면에서 해당 요소가 어디 있는지를 알아야 합니다. 그 과정에서 강제 레이아웃 계산(reflow)이 발생할 수 있습니다.

`requestAnimationFrame`으로 다음 프레임의 렌더링 직전으로 미루면, 브라우저가 DOM 업데이트와 레이아웃 계산이 끝난 후 실행될 가능성이 커지기 때문에 focus 실패 타이밍 가능성을 낮추고, 불필요한 강제 레이아웃을 막을 수 있습니다.

<!-- 이 PR에서 완료된 주요 내용을 간단히 설명해주세요 -->

---

## 기타

<!-- 코드 리뷰 시 참고할 사항을 작성해주세요 -->
<!-- 특히 주의깊게 봐야 하는 파일이나 코드가 있다면 명시해주세요 -->
<!-- 구현 중 고민했던 부분이나 리뷰어에게 질문하고 싶은 내용을 적어주세요 -->
