### PR TITLE
[Feat] 로그인한 경우 멤버리스트에 프로필 이미지 추가

### DIFF
--- a/src/app/(with-sidebar)/issue/_components/layout/issue-sidebar.tsx
+++ b/src/app/(with-sidebar)/issue/_components/layout/issue-sidebar.tsx
@@ -60,21 +60,21 @@ export default function IssueSidebar() {
           <S.SidebarList>
             {topicId
               ? filteredIssues.map((issue) => (
-                  <SidebarItem
-                    key={issue.id}
-                    title={issue.title}
-                    href={`/issue/${issue.id}`}
-                    status={issue.status as any}
-                  />
-                ))
+                <SidebarItem
+                  key={issue.id}
+                  title={issue.title}
+                  href={`/issue/${issue.id}`}
+                  status={issue.status as any}
+                />
+              ))
               : filteredStaticIssues.map((issue) => (
-                  <SidebarItem
-                    key={issue.title}
-                    title={issue.title}
-                    href={issue.href}
-                    status={issue.status}
-                  />
-                ))}
+                <SidebarItem
+                  key={issue.title}
+                  title={issue.title}
+                  href={issue.href}
+                  status={issue.status}
+                />
+              ))}
           </S.SidebarList>
         </>
       )}
@@ -98,6 +98,7 @@ export default function IssueSidebar() {
                   id={user.id}
                   name={user.nickname}
                   role={user.role}
+                  profile={user.profile || undefined}
                   isConnected={isOnline}
                 />
               );

--- a/src/app/api/issues/[issueId]/members/route.ts
+++ b/src/app/api/issues/[issueId]/members/route.ts
@@ -25,6 +25,7 @@ export async function GET(
       id: member.userId,
       nickname: member.nickname,
       role: member.role,
+      profile: member.user?.image,
       isConnected: true, // 지금은 기본값, 나중에 SSE 붙이면 여기서 합치면 됨
     }));
 

--- a/src/lib/api/issue.ts
+++ b/src/lib/api/issue.ts
@@ -67,6 +67,7 @@ export function getIssueMembers(issueId: string) {
       id: string;
       nickname: string;
       role: string;
+      profile?: string | null;
       isConnected: boolean;
     }>
   >({

--- a/src/lib/repositories/issue-member.repository.ts
+++ b/src/lib/repositories/issue-member.repository.ts
@@ -76,6 +76,11 @@ export const issueMemberRepository = {
         userId: true,
         role: true,
         nickname: true,
+        user: {
+          select: {
+            image: true,
+          },
+        },
       },
     });
   },


### PR DESCRIPTION
## 관련 이슈

close #373 

---

## 완료 작업

로그인한 경우 멤버리스트에 프로필 사진이 보이게끔 UI를 수정했습니다.

- `issue-member.repository.ts`: `findMembersByIssueId`에 사용자 프로필을 가져오는 로직 추가
- `issue.ts`, `route.ts`: api 응답에 `profile` 추가
- `issue-sidebar.tsx`: 프로필 추가

---

## 기타

<img width="257" height="222" alt="image" src="https://github.com/user-attachments/assets/ffeb2d2b-2c00-4e33-91df-2bd5fac70c84" />