### PR TITLE
[Fix] 카테고리, 브레인스토밍 외 아이디어 드래그 비활성화

### DIFF
--- a/src/app/(with-sidebar)/issue/_components/idea-card/idea-card.tsx
+++ b/src/app/(with-sidebar)/issue/_components/idea-card/idea-card.tsx
@@ -111,7 +111,7 @@ export default function IdeaCard(props: IdeaCardProps) {
   // 드래그 로직
 
   // dnd-kit useDraggable
-  const canDrag = issueStatus === ISSUE_STATUS.CATEGORIZE;
+  const canDrag = issueStatus === ISSUE_STATUS.BRAINSTORMING || issueStatus === ISSUE_STATUS.CATEGORIZE;
 
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: props.id || 'idea-unknown',


### PR DESCRIPTION
## 관련 이슈

#381

---

## 완료 작업

https://github.com/user-attachments/assets/21606c68-e4b5-4104-837d-ed14857520ee


- BRAINSTORMING | CATEGORIZE 단계에서만 아이디어 카드 드래그가 시작되도록 제한했습니다.

---

## 기타

<!-- 코드 리뷰 시 참고할 사항을 작성해주세요 -->
<!-- 특히 주의깊게 봐야 하는 파일이나 코드가 있다면 명시해주세요 -->
<!-- 구현 중 고민했던 부분이나 리뷰어에게 질문하고 싶은 내용을 적어주세요 -->
